### PR TITLE
Refine allowed product/account configuration pages

### DIFF
--- a/mc_product_restrictions/__init__.py
+++ b/mc_product_restrictions/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/mc_product_restrictions/__manifest__.py
+++ b/mc_product_restrictions/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'MC Product Restrictions',
+    'version': '10.0.1.0.0',
+    'summary': 'Restrict product and account visibility per user.',
+    'author': 'Your Company',
+    'license': 'LGPL-3',
+    'website': 'https://example.com',
+    'category': 'Product',
+    'depends': ['base', 'product', 'account'],
+    'data': [
+        'security/res_groups.xml',
+        'security/ir_rule_data.xml',
+        'views/res_users_view.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/mc_product_restrictions/models/__init__.py
+++ b/mc_product_restrictions/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import res_users
+from . import product_template
+from . import account_account

--- a/mc_product_restrictions/models/account_account.py
+++ b/mc_product_restrictions/models/account_account.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = 'account.account'
+
+    restricted_user_ids = fields.Many2many(
+        comodel_name='res.users',
+        relation='res_users_account_account_rel',
+        column1='account_id',
+        column2='user_id',
+        string='Restricted Users',
+        help='Users allowed to access this account when account restrictions are enabled.')
+
+    @api.model
+    def create(self, vals):
+        account = super(AccountAccount, self).create(vals)
+        account._add_creator_to_restricted_users(vals)
+        return account
+
+    def _add_creator_to_restricted_users(self, vals):
+        if (
+            self.env.user.has_group('mc_product_restrictions.group_product_restriction')
+            and 'restricted_user_ids' not in vals
+        ):
+            self.sudo().write({'restricted_user_ids': [(4, self.env.user.id)]})

--- a/mc_product_restrictions/models/product_template.py
+++ b/mc_product_restrictions/models/product_template.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    restricted_user_ids = fields.Many2many(
+        comodel_name='res.users',
+        relation='res_users_product_template_rel',
+        column1='product_tmpl_id',
+        column2='user_id',
+        string='Restricted Users',
+        help='Users allowed to access this product when product restrictions are enabled.')
+
+    @api.model
+    def create(self, vals):
+        template = super(ProductTemplate, self).create(vals)
+        template._add_creator_to_restricted_users(vals)
+        return template
+
+    def _add_creator_to_restricted_users(self, vals):
+        if (
+            self.env.user.has_group('mc_product_restrictions.group_product_restriction')
+            and 'restricted_user_ids' not in vals
+        ):
+            self.sudo().write({'restricted_user_ids': [(4, self.env.user.id)]})

--- a/mc_product_restrictions/models/res_users.py
+++ b/mc_product_restrictions/models/res_users.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    restricted_product_ids = fields.Many2many(
+        comodel_name='product.template',
+        relation='res_users_product_template_rel',
+        column1='user_id',
+        column2='product_tmpl_id',
+        string='Allowed Products',
+        help='Products that this user is allowed to access.')
+
+    restricted_account_ids = fields.Many2many(
+        comodel_name='account.account',
+        relation='res_users_account_account_rel',
+        column1='user_id',
+        column2='account_id',
+        string='Allowed Accounts',
+        help='Accounts that this user is allowed to access.')

--- a/mc_product_restrictions/security/ir_rule_data.xml
+++ b/mc_product_restrictions/security/ir_rule_data.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_restriction_rule" model="ir.rule">
+        <field name="name">Product Template Restriction</field>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="groups" eval="[(4, ref('mc_product_restrictions.group_product_restriction'))]"/>
+        <field name="domain_force">['|', ("restricted_user_ids", "=", False), ("restricted_user_ids", "in", [user.id])]</field>
+    </record>
+
+    <record id="product_product_restriction_rule" model="ir.rule">
+        <field name="name">Product Variant Restriction</field>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="groups" eval="[(4, ref('mc_product_restrictions.group_product_restriction'))]"/>
+        <field name="domain_force">['|', ("product_tmpl_id.restricted_user_ids", "=", False), ("product_tmpl_id.restricted_user_ids", "in", [user.id])]</field>
+    </record>
+
+    <record id="account_account_restriction_rule" model="ir.rule">
+        <field name="name">Account Restriction</field>
+        <field name="model_id" ref="account.model_account_account"/>
+        <field name="groups" eval="[(4, ref('mc_product_restrictions.group_product_restriction'))]"/>
+        <field name="domain_force">['|', ("restricted_user_ids", "=", False), ("restricted_user_ids", "in", [user.id])]</field>
+    </record>
+</odoo>

--- a/mc_product_restrictions/security/res_groups.xml
+++ b/mc_product_restrictions/security/res_groups.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="group_product_restriction" model="res.groups">
+        <field name="name">Product and Account Restrictions</field>
+        <field name="category_id" ref="base.module_category_product"/>
+    </record>
+</odoo>

--- a/mc_product_restrictions/views/res_users_view.xml
+++ b/mc_product_restrictions/views/res_users_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_users_form_product_restrictions" model="ir.ui.view">
+        <field name="name">res.users.form.product.restrictions</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet/notebook" position="inside">
+                <page string="Allowed products" groups="mc_product_restrictions.group_product_restriction">
+                    <group>
+                        <field name="restricted_product_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
+                    </group>
+                </page>
+                <page string="Allowed accounts" groups="mc_product_restrictions.group_product_restriction">
+                    <group>
+                        <field name="restricted_account_ids" widget="many2many_tags" options="{'no_create_edit': True}"/>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- allow product and account record rules to fall back to unrestricted access when no allowed users are set
- rename the user form notebook pages to "Allowed products" and "Allowed accounts" per requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65fcd37888323bf911899c67595a6